### PR TITLE
Allow rewrite of Aoe_TemplateHints_Model_Observer

### DIFF
--- a/app/code/community/Aoe/TemplateHints/etc/config.xml
+++ b/app/code/community/Aoe/TemplateHints/etc/config.xml
@@ -33,7 +33,7 @@
                 <observers>
                     <aoe_templatehints>
                         <type>singleton</type>
-                        <class>Aoe_TemplateHints_Model_Observer</class>
+                        <class>aoe_templatehints/observer</class>
                         <method>core_block_abstract_to_html_after</method>
                     </aoe_templatehints>
                 </observers>


### PR DESCRIPTION
The usage of a direct class name prohibits other modules to rewrite this observer.
